### PR TITLE
Throw original error on httprequest errors

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,7 +2,7 @@
   <code_scheme name="Project" version="173">
     <option name="LINE_SEPARATOR" value="&#10;" />
     <option name="SOFT_MARGINS" value="120" />
-    <TypeScriptCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
       <option name="FORCE_SEMICOLON_STYLE" value="true" />
       <option name="ALIGN_OBJECT_PROPERTIES" value="1" />
       <option name="ALIGN_VAR_STATEMENTS" value="2" />

--- a/spec/components/httprequest/RequestJSWrapperSpec.ts
+++ b/spec/components/httprequest/RequestJSWrapperSpec.ts
@@ -93,8 +93,8 @@ describe('A RequestJSWrapper', () => {
         timeout: 1,
       }).execute();
     } catch (error) {
-      expect(error.name).toEqual('HTTPRequestError');
-      expect(error.message).toEqual('ESOCKETTIMEDOUT');
+      expect(error.name).toEqual('RequestError');
+      expect(error.message).toEqual('Error: ESOCKETTIMEDOUT');
 
       return;
     }
@@ -108,8 +108,8 @@ describe('A RequestJSWrapper', () => {
     try {
       await new RequestJSWrapper(options).execute();
     } catch (error) {
-      expect(error.name).toEqual('HTTPRequestTimedoutError');
-      expect(error.message).toEqual('Request timed out');
+      expect(error.name).toEqual('RequestError');
+      expect(error.message).toEqual('Error: ETIMEDOUT');
 
       return;
     }
@@ -123,8 +123,8 @@ describe('A RequestJSWrapper', () => {
     try {
       await new RequestJSWrapper(options).execute();
     } catch (error) {
-      expect(error.name).toEqual('HTTPRequestError');
-      expect(error.message).toEqual('CUSTOM');
+      expect(error.name).toEqual('RequestError');
+      expect(error.message).toEqual('Error: CUSTOM');
 
       return;
     }

--- a/src/components/httprequest/RequestJSWrapper.ts
+++ b/src/components/httprequest/RequestJSWrapper.ts
@@ -1,7 +1,5 @@
 import request from 'request-promise-native';
 import {HTTPRequest, HTTPRequestOptions, HTTPRequestResponse} from './HTTPRequest';
-import {HTTPRequestError} from './HTTPRequestError';
-import {HTTPRequestTimedoutError} from './HTTPRequestTimedoutError';
 
 const baseRequest = request.defaults({
   gzip: true,
@@ -18,21 +16,12 @@ export class RequestJSWrapper implements HTTPRequest {
   }
 
   public async execute(): Promise<HTTPRequestResponse> {
-    let response: request.FullResponse;
-    try {
-      response = await baseRequest({
-        proxy:                   false,
-        ...this.options,
-        resolveWithFullResponse: true,
-        simple:                  false,
-      });
-    } catch (requestError) {
-      if (requestError.error.message === 'ETIMEDOUT') {
-        throw new HTTPRequestTimedoutError('Request timed out');
-      }
-
-      throw new HTTPRequestError(requestError.error.message);
-    }
+    const response = await baseRequest({
+      proxy:                   false,
+      ...this.options,
+      resolveWithFullResponse: true,
+      simple:                  false,
+    }).promise();
 
     return {
       statusCode: response.statusCode,


### PR DESCRIPTION
Encapsulating the error with another error removes information about the error. Throwing the original error makes more sense