### PR TITLE
FOOD-1960: Add redis queries and tests

### DIFF
--- a/spec/components/redis/MeasurableCacheQuerySpec.ts
+++ b/spec/components/redis/MeasurableCacheQuerySpec.ts
@@ -1,0 +1,46 @@
+import {CacheQuery} from '../../../src/components/redis/CacheQuery';
+import {MeasurableCacheQuery} from '../../../src/components/redis/MeasurableCacheQuery';
+
+describe('A MeasureableCacheQuery', () => {
+  const cacheQueryMock = {} as CacheQuery<any>;
+  const measurableCacheQuery = new MeasurableCacheQuery(cacheQueryMock);
+
+  describe('Succesfully', () => {
+    let result: unknown;
+
+    beforeEach(async () => {
+      cacheQueryMock.execute = () => Promise.resolve({});
+
+      result = await measurableCacheQuery.execute();
+    });
+
+    it('Returns the query result', () => {
+      expect(result).toEqual({});
+    });
+
+    it('Contains the result:success tag', () => {
+      expect(measurableCacheQuery.tags).toContain('result:success');
+    });
+  });
+
+  describe('Unsuccesfully', () => {
+    let error: unknown;
+    const throwError = new Error('Error');
+
+    beforeEach(async () => {
+      cacheQueryMock.execute = () => Promise.reject(throwError);
+
+      await measurableCacheQuery.execute().catch((e) => {
+        error = e;
+      });
+    });
+
+    it('Returns the query result', () => {
+      expect(error).toBe(throwError);
+    });
+
+    it('Contains the result:success tag', () => {
+      expect(measurableCacheQuery.tags).toContain('result:failed');
+    });
+  });
+});

--- a/spec/components/redis/RedisGetMultipleSpec.ts
+++ b/spec/components/redis/RedisGetMultipleSpec.ts
@@ -1,0 +1,86 @@
+import IORedis from 'ioredis';
+import {RedisClient} from '../../../src/components/redis/RedisClient';
+import {RedisGetMultiple} from '../../../src/components/redis/RedisGetMultiple';
+
+describe('A RedisGetMultiple', () => {
+  const ReplyError = require('ioredis').ReplyError;
+  const clientMock = {} as IORedis.Redis;
+  const redisMock = {
+    client: clientMock,
+  } as RedisClient;
+  let redisGetMultiple: RedisGetMultiple<any>;
+  const successfulResult = {
+    id1: {value: {test: 'test'}},
+    id2: {value: {test: 'test'}},
+  };
+  const mgetResult = [JSON.stringify(successfulResult.id1), JSON.stringify(successfulResult.id2)];
+
+  describe('Instantiated with query keys', () => {
+    let result: any;
+
+    beforeEach(async () => {
+      clientMock.mget = () => Promise.resolve(mgetResult);
+
+      redisGetMultiple = new RedisGetMultiple(redisMock, ['id1', 'id2']);
+      result = await redisGetMultiple.execute();
+    });
+
+    it('Returns parsed objects', async () => {
+      expect(result).toEqual(successfulResult);
+    });
+  });
+
+  describe('Instantiated without query keys', () => {
+    let result: any;
+
+    beforeEach(async () => {
+      clientMock.mget = () => Promise.resolve(mgetResult);
+
+      redisGetMultiple = new RedisGetMultiple(redisMock, []);
+      result = await redisGetMultiple.execute();
+    });
+
+    it('Returns an empty object', async () => {
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('Receiving unfound query results', () => {
+    const halfSuccessfulResult = {id2: {value: {test: 'test'}}};
+    let result: any;
+
+    beforeEach(async () => {
+      // tslint:disable-next-line:no-null-keyword
+      const mgetResult = [null, JSON.stringify({value: {test: 'test'}})];
+      clientMock.mget = () => Promise.resolve(mgetResult);
+      const redisMock = {
+        client: clientMock,
+      } as RedisClient;
+      redisGetMultiple = new RedisGetMultiple(redisMock, ['unexistent', 'id2']);
+      result = await redisGetMultiple.execute();
+    });
+
+    it('Returns a filtered object', async () => {
+      expect(result).toEqual(halfSuccessfulResult);
+    });
+  });
+
+  describe('Receiving a failed query result', () => {
+    let error: Error;
+
+    beforeEach(async () => {
+      redisGetMultiple = new RedisGetMultiple(redisMock, ['id1', 'id2']);
+      clientMock.mget = () => Promise.reject(new ReplyError());
+
+      try {
+        await redisGetMultiple.execute();
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    it('Returns a Redis ReplyError', async () => {
+      expect(error).toEqual(jasmine.any(ReplyError));
+    });
+  });
+});

--- a/spec/components/redis/RedisGetSpec.ts
+++ b/spec/components/redis/RedisGetSpec.ts
@@ -1,0 +1,59 @@
+import IORedis from 'ioredis';
+import {RedisClient} from '../../../src/components/redis/RedisClient';
+import {RedisGet} from '../../../src/components/redis/RedisGet';
+
+describe('A RedisGet', () => {
+  const ReplyError       = require('ioredis').ReplyError;
+  const clientMock       = {} as IORedis.Redis;
+  const redisMock        = {
+    client: clientMock,
+  } as RedisClient;
+  const redisGet         = new RedisGet(redisMock, '');
+  const successfulResult = {property: ''};
+  const jsonString       = JSON.stringify({property: ''});
+
+  describe('Receiving a successful Redis query', () => {
+    let result: any;
+    beforeEach(async () => {
+      clientMock.get         = () => Promise.resolve(jsonString);
+
+      result = await redisGet.execute();
+    });
+
+    it('Returns a parsed object', async () => {
+      expect(result).toEqual(successfulResult);
+    });
+  });
+
+  describe('Receiving a Not Found Redis query', () => {
+    let result: any;
+
+    beforeEach(async () => {
+      // tslint:disable-next-line:no-null-keyword
+      clientMock.get = () => Promise.resolve(null);
+      result         = await redisGet.execute();
+    });
+
+    it('Returns void 0', async () => {
+      expect(result).toEqual(void 0);
+    });
+  });
+
+  describe('Receiving a failed Redis query', () => {
+    let error: Error;
+
+    beforeEach(async () => {
+      clientMock.get = () => Promise.reject(new ReplyError());
+
+      try {
+        await redisGet.execute();
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    it('Returns a Redis ReplyError', async () => {
+      expect(error).toEqual(jasmine.any(ReplyError));
+    });
+  });
+});

--- a/spec/components/redis/RedisInsertSpec.ts
+++ b/spec/components/redis/RedisInsertSpec.ts
@@ -1,0 +1,64 @@
+import IORedis from 'ioredis';
+import {RedisClient} from '../../../src/components/redis/RedisClient';
+import {CacheInsertOptions} from '../../../src/components/redis/CacheInsertOptions';
+import {RedisInsert} from '../../../src/components/redis/RedisInsert';
+
+describe('A RedisGet', () => {
+  const ReplyError = require('ioredis').ReplyError;
+  const clientMock = {} as IORedis.Redis;
+  const redisMock = {
+    client: clientMock,
+  } as RedisClient;
+  let redisInsert: RedisInsert;
+
+  describe('With CacheInsertOptions', () => {
+    let result: any;
+
+    beforeEach(async () => {
+      clientMock.set = () => Promise.resolve('');
+
+      redisInsert = new RedisInsert(redisMock, '', {property: ''}, {} as CacheInsertOptions);
+
+      result = await redisInsert.execute();
+    });
+
+    it('Inserts without error', async () => {
+      expect(result).toEqual(void 0);
+    });
+  });
+
+  describe('Without CacheInsertOptions', () => {
+    let result: any;
+
+    beforeEach(async () => {
+      clientMock.set = () => Promise.resolve('');
+
+      redisInsert = new RedisInsert(redisMock, '', {});
+      result = await redisInsert.execute();
+    });
+
+    it('Inserts without error', async () => {
+      expect(result).toEqual(void 0);
+    });
+  });
+
+  describe('Receiving a failed Redis query', () => {
+    let error: Error;
+
+    beforeEach(async () => {
+      redisInsert = new RedisInsert(redisMock, '', {property: ''}, {} as CacheInsertOptions);
+
+      clientMock.set = () => Promise.reject(new ReplyError());
+
+      try {
+        await redisInsert.execute();
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    it('Returns a Redis ReplyError', async () => {
+      expect(error).toEqual(jasmine.any(ReplyError));
+    });
+  });
+});

--- a/spec/components/redis/RedisQueryFactorySpec.ts
+++ b/spec/components/redis/RedisQueryFactorySpec.ts
@@ -1,0 +1,24 @@
+import {RedisClient} from '../../../src/components/redis/RedisClient';
+import {AsyncMeasurer} from '../../../src/components/telemetry/AsyncMeasurer';
+import {RedisQueryFactory} from '../../../src/components/redis/RedisQueryFactory';
+import {loggerMock} from '../../helpers/mocks/loggerMock';
+import {CacheQueryTelemetry} from '../../../src/components/redis/CacheQueryTelemetry';
+
+describe('A CacheQueryFactory', () => {
+  const couchbaseMock = {} as RedisClient;
+  const measurer      = {} as AsyncMeasurer;
+
+  const queryFactory = new RedisQueryFactory(couchbaseMock, loggerMock, measurer);
+
+  it('Can return a Get query instance', () => {
+    expect(queryFactory.createGet('id') instanceof CacheQueryTelemetry).toEqual(true);
+  });
+
+  it('Can return a GetMultiple query instance', () => {
+    expect(queryFactory.createGetMultiple(['id1', 'id2']) instanceof CacheQueryTelemetry).toEqual(true);
+  });
+
+  it('Can return a Insert query instance', () => {
+    expect(queryFactory.createInsert('id1', {}) instanceof CacheQueryTelemetry).toEqual(true);
+  });
+});

--- a/spec/components/redis/RedisQueryFactorySpec.ts
+++ b/spec/components/redis/RedisQueryFactorySpec.ts
@@ -1,14 +1,13 @@
 import {RedisClient} from '../../../src/components/redis/RedisClient';
-import {AsyncMeasurer} from '../../../src/components/telemetry/AsyncMeasurer';
 import {RedisQueryFactory} from '../../../src/components/redis/RedisQueryFactory';
-import {loggerMock} from '../../helpers/mocks/loggerMock';
 import {CacheQueryTelemetry} from '../../../src/components/redis/CacheQueryTelemetry';
+import {AsyncTelemetry} from '../../../src/components/telemetry/AsyncTelemetry';
 
 describe('A CacheQueryFactory', () => {
-  const couchbaseMock = {} as RedisClient;
-  const measurer      = {} as AsyncMeasurer;
+  const couchbaseMock      = {} as RedisClient;
+  const asyncTelemetryMock = {} as AsyncTelemetry;
 
-  const queryFactory = new RedisQueryFactory(couchbaseMock, loggerMock, measurer);
+  const queryFactory = new RedisQueryFactory(couchbaseMock, asyncTelemetryMock);
 
   it('Can return a Get query instance', () => {
     expect(queryFactory.createGet('id') instanceof CacheQueryTelemetry).toEqual(true);

--- a/src/components/redis/CacheInsertOptions.ts
+++ b/src/components/redis/CacheInsertOptions.ts
@@ -1,0 +1,3 @@
+export interface CacheInsertOptions {
+  expiry?: number;
+}

--- a/src/components/redis/CacheQuery.ts
+++ b/src/components/redis/CacheQuery.ts
@@ -1,0 +1,3 @@
+export interface CacheQuery<T> {
+  execute: () => Promise<T>;
+}

--- a/src/components/redis/CacheQueryFactory.ts
+++ b/src/components/redis/CacheQueryFactory.ts
@@ -1,0 +1,8 @@
+import {CacheQuery} from './CacheQuery';
+import {CacheInsertOptions} from './CacheInsertOptions';
+
+export interface CacheQueryFactory {
+  createGet(id: string): CacheQuery<any>;
+  createGetMultiple(ids: string[]): CacheQuery<Record<string, any>>;
+  createInsert(id: string, document: any, options?: CacheInsertOptions): CacheQuery<void>;
+}

--- a/src/components/redis/CacheQueryTelemetry.ts
+++ b/src/components/redis/CacheQueryTelemetry.ts
@@ -1,33 +1,21 @@
-import * as Logger from 'bunyan';
 import {CacheQuery} from './CacheQuery';
 import {Measurable} from '../telemetry/Measurable';
-import {AsyncMeasurer} from '../telemetry/AsyncMeasurer';
+import {AsyncTelemetry} from '../telemetry/AsyncTelemetry';
 
 export class CacheQueryTelemetry<T> implements CacheQuery<T> {
   private readonly query: CacheQuery<T> & Measurable<T>;
-  private readonly logger: Logger;
-  private readonly measurer: AsyncMeasurer;
+  private readonly asyncTelemetry: AsyncTelemetry;
   private readonly defaultStatsDTags?: string[];
 
-  public constructor(logger: Logger,
-                     query: CacheQuery<T> & Measurable<T>,
-                     measurer: AsyncMeasurer,
+  public constructor(query: CacheQuery<T> & Measurable<T>,
+                     asyncTelemetry: AsyncTelemetry,
                      defaultStatsDTags?: string[]) {
-    this.logger            = logger;
-    this.measurer          = measurer;
+    this.asyncTelemetry    = asyncTelemetry;
     this.query             = query;
     this.defaultStatsDTags = defaultStatsDTags;
   }
 
   public async execute(): Promise<T> {
-    try {
-      return await this.measurer.measure(this.query, this.defaultStatsDTags);
-    } catch (error) {
-      this.logger.error({
-        error:     error,
-      }, 'Error while querying Cache');
-
-      throw error;
-    }
+    return await this.asyncTelemetry.execute(this.query, this.defaultStatsDTags);
   }
 }

--- a/src/components/redis/CacheQueryTelemetry.ts
+++ b/src/components/redis/CacheQueryTelemetry.ts
@@ -1,0 +1,33 @@
+import * as Logger from 'bunyan';
+import {CacheQuery} from './CacheQuery';
+import {Measurable} from '../telemetry/Measurable';
+import {AsyncMeasurer} from '../telemetry/AsyncMeasurer';
+
+export class CacheQueryTelemetry<T> implements CacheQuery<T> {
+  private readonly query: CacheQuery<T> & Measurable<T>;
+  private readonly logger: Logger;
+  private readonly measurer: AsyncMeasurer;
+  private readonly defaultStatsDTags?: string[];
+
+  public constructor(logger: Logger,
+                     query: CacheQuery<T> & Measurable<T>,
+                     measurer: AsyncMeasurer,
+                     defaultStatsDTags?: string[]) {
+    this.logger            = logger;
+    this.measurer          = measurer;
+    this.query             = query;
+    this.defaultStatsDTags = defaultStatsDTags;
+  }
+
+  public async execute(): Promise<T> {
+    try {
+      return await this.measurer.measure(this.query, this.defaultStatsDTags);
+    } catch (error) {
+      this.logger.error({
+        error:     error,
+      }, 'Error while querying Cache');
+
+      throw error;
+    }
+  }
+}

--- a/src/components/redis/MeasurableCacheQuery.ts
+++ b/src/components/redis/MeasurableCacheQuery.ts
@@ -1,0 +1,41 @@
+import {CacheQuery} from './CacheQuery';
+import {Measurable} from '../telemetry/Measurable';
+
+export class MeasurableCacheQuery<T> implements CacheQuery<T>, Measurable<T> {
+  public readonly type: string                         = 'CacheQuery';
+  private result: 'success' | 'failed' | 'notexecuted' = 'notexecuted';
+  private readonly query: CacheQuery<T>;
+
+  public constructor(query: CacheQuery<T>) {
+    this.query = query;
+  }
+
+  public get name(): string {
+    return this.query.constructor.name;
+  }
+
+  public get options(): object {
+    return {};
+  }
+
+  public get tags(): string[] {
+    return [
+      `result:${this.result}`,
+      `type:${this.name}`,
+    ];
+  }
+
+  public async execute(): Promise<T> {
+    try {
+      const result = await this.query.execute();
+
+      this.result = 'success';
+
+      return result;
+    } catch (error) {
+      this.result = 'failed';
+
+      throw error;
+    }
+  }
+}

--- a/src/components/redis/RedisGet.ts
+++ b/src/components/redis/RedisGet.ts
@@ -1,0 +1,18 @@
+import {CacheQuery} from './CacheQuery';
+import {RedisClient} from './RedisClient';
+
+export class RedisGet implements CacheQuery<any> {
+  private readonly redis: RedisClient;
+  private readonly key: string;
+
+  public constructor(redis: RedisClient, key: string) {
+    this.redis = redis;
+    this.key = key;
+  }
+
+  public async execute(): Promise<any> {
+    const result = await this.redis.client.get(this.key);
+
+    return result ? JSON.parse(result) : void 0;
+  }
+}

--- a/src/components/redis/RedisGetMultiple.ts
+++ b/src/components/redis/RedisGetMultiple.ts
@@ -1,0 +1,38 @@
+import {CacheQuery} from './CacheQuery';
+import {RedisClient} from './RedisClient';
+
+export class RedisGetMultiple<T> implements CacheQuery<Record<string, T>> {
+  private readonly redis: RedisClient;
+  private readonly keys: string[];
+
+  public constructor(redis: RedisClient, keys: string[]) {
+    this.redis = redis;
+    this.keys  = keys;
+  }
+
+  public async execute(): Promise<any> {
+    if (this.keys.length === 0) {
+      return {};
+    }
+
+    const stringifiedArray: (string | null)[] = await this.redis.client.mget(...this.keys);
+
+    return this.parseMultiGetResult(stringifiedArray);
+  }
+
+  private parseMultiGetResult(stringifiedArray: (string | null)[]): Record<string, any> {
+    const documentsMap: Record<string, any> = {};
+
+    this.keys.forEach((key, index) => {
+      const document = stringifiedArray[index];
+
+      if (!document) {
+        return;
+      }
+
+      documentsMap[key] = JSON.parse(document);
+    });
+
+    return documentsMap;
+  }
+}

--- a/src/components/redis/RedisInsert.ts
+++ b/src/components/redis/RedisInsert.ts
@@ -1,0 +1,27 @@
+import {CacheQuery} from './CacheQuery';
+import {RedisClient} from './RedisClient';
+import {CacheInsertOptions} from './CacheInsertOptions';
+
+export class RedisInsert implements CacheQuery<void> {
+  private readonly redis: RedisClient;
+  private readonly key: string;
+  private readonly value: any;
+  private readonly options: CacheInsertOptions;
+
+  public constructor(redis: RedisClient, key: string, value: any, options: CacheInsertOptions = {}) {
+    this.redis = redis;
+    this.key = key;
+    this.value = value;
+    this.options = options;
+  }
+
+  public execute(): Promise<void> {
+    return this.redis.client
+      .set(this.key, JSON.stringify(this.value))
+      .then(() => {
+        if (this.options.expiry) {
+          this.redis.client.expire(this.key, this.options.expiry);
+        }
+      });
+  }
+}

--- a/src/components/redis/RedisQueryFactory.ts
+++ b/src/components/redis/RedisQueryFactory.ts
@@ -1,6 +1,4 @@
-import * as Logger from 'bunyan';
 import {CacheQueryFactory} from './CacheQueryFactory';
-import {AsyncMeasurer} from '../telemetry/AsyncMeasurer';
 import {RedisClient} from './RedisClient';
 import {CacheInsertOptions} from './CacheInsertOptions';
 import {CacheQuery} from './CacheQuery';
@@ -9,17 +7,16 @@ import {RedisGetMultiple} from './RedisGetMultiple';
 import {RedisInsert} from './RedisInsert';
 import {CacheQueryTelemetry} from './CacheQueryTelemetry';
 import {MeasurableCacheQuery} from './MeasurableCacheQuery';
+import {AsyncTelemetry} from '../telemetry/AsyncTelemetry';
 
 export class RedisQueryFactory implements CacheQueryFactory {
   private readonly redis: RedisClient;
-  private readonly logger: Logger;
-  private readonly measurer: AsyncMeasurer;
+  private readonly asyncTelemetry: AsyncTelemetry;
   private readonly defaultStatsDTags?: string[];
 
-  public constructor(redis: RedisClient, logger: Logger, measurer: AsyncMeasurer, defaultStatsDTags?: string[]) {
+  public constructor(redis: RedisClient, asyncTelemetry: AsyncTelemetry, defaultStatsDTags?: string[]) {
     this.redis             = redis;
-    this.logger            = logger;
-    this.measurer          = measurer;
+    this.asyncTelemetry    = asyncTelemetry;
     this.defaultStatsDTags = defaultStatsDTags;
   }
 
@@ -36,6 +33,6 @@ export class RedisQueryFactory implements CacheQueryFactory {
   }
 
   private createMeasuredQuery<T>(query: CacheQuery<T>): CacheQuery<T> {
-    return new CacheQueryTelemetry(this.logger, new MeasurableCacheQuery(query), this.measurer, this.defaultStatsDTags);
+    return new CacheQueryTelemetry(new MeasurableCacheQuery(query), this.asyncTelemetry, this.defaultStatsDTags);
   }
 }

--- a/src/components/redis/RedisQueryFactory.ts
+++ b/src/components/redis/RedisQueryFactory.ts
@@ -1,0 +1,41 @@
+import * as Logger from 'bunyan';
+import {CacheQueryFactory} from './CacheQueryFactory';
+import {AsyncMeasurer} from '../telemetry/AsyncMeasurer';
+import {RedisClient} from './RedisClient';
+import {CacheInsertOptions} from './CacheInsertOptions';
+import {CacheQuery} from './CacheQuery';
+import {RedisGet} from './RedisGet';
+import {RedisGetMultiple} from './RedisGetMultiple';
+import {RedisInsert} from './RedisInsert';
+import {CacheQueryTelemetry} from './CacheQueryTelemetry';
+import {MeasurableCacheQuery} from './MeasurableCacheQuery';
+
+export class RedisQueryFactory implements CacheQueryFactory {
+  private readonly redis: RedisClient;
+  private readonly logger: Logger;
+  private readonly measurer: AsyncMeasurer;
+  private readonly defaultStatsDTags?: string[];
+
+  public constructor(redis: RedisClient, logger: Logger, measurer: AsyncMeasurer, defaultStatsDTags?: string[]) {
+    this.redis             = redis;
+    this.logger            = logger;
+    this.measurer          = measurer;
+    this.defaultStatsDTags = defaultStatsDTags;
+  }
+
+  public createGet(id: string): CacheQuery<any> {
+    return this.createMeasuredQuery(new RedisGet(this.redis, id));
+  }
+
+  public createGetMultiple(ids: string[]): CacheQuery<Record<string, any>> {
+    return this.createMeasuredQuery(new RedisGetMultiple(this.redis, ids));
+  }
+
+  public createInsert(id: string, document: any, options?: CacheInsertOptions): CacheQuery<void> {
+    return this.createMeasuredQuery(new RedisInsert(this.redis, id, document, options));
+  }
+
+  private createMeasuredQuery<T>(query: CacheQuery<T>): CacheQuery<T> {
+    return new CacheQueryTelemetry(this.logger, new MeasurableCacheQuery(query), this.measurer, this.defaultStatsDTags);
+  }
+}


### PR DESCRIPTION
The Redis queries are currently in UX-API, other services will also cache data in redis so let's move these files to common library.